### PR TITLE
Update m4/ac_find_gap.m4 for better GAP 4.9 compat

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,9 +12,8 @@ GAPINSTALLLIB = $(abs_top_srcdir)/$(BINARCHDIR)/profiling.so
 lib_LTLIBRARIES = profiling.la
 
 profiling_la_SOURCES = src/profiling.cc
-profiling_la_CPPFLAGS = $(GAP_CPPFLAGS) -DCONFIG_H
-# Note that the latter is only for GAP 4.4.12
-profiling_la_LDFLAGS = -module -avoid-version
+profiling_la_CPPFLAGS = $(GAP_CPPFLAGS)
+profiling_la_LDFLAGS = $(GAP_LDFLAGS) -module -avoid-version
 if SYS_IS_CYGWIN
 profiling_la_LDFLAGS += -no-undefined -version-info 0:0:0 -Wl,$(GAPROOT)/bin/$(GAPARCH)/gap.dll
 endif

--- a/m4/ac_find_gap.m4
+++ b/m4/ac_find_gap.m4
@@ -1,6 +1,6 @@
 # Find the location of GAP
 # Sets GAPROOT, GAPARCH and GAP_CPPFLAGS appropriately
-# Can be configured using --with-gaproot=... and --with-configname=...
+# Can be configured using --with-gaproot=... and CONFIGNAME=...
 #######################################################################
 
 AC_DEFUN([AC_FIND_GAP],
@@ -103,61 +103,70 @@ AC_DEFUN([AC_FIND_GAP],
   fi
 
 
-  #####################################
-  # Now check for the GAP header files
-
-  bad=0
-  AC_MSG_CHECKING([for GAP include files])
-  if test -r $GAPROOT/src/compiled.h; then
-    AC_MSG_RESULT([$GAPROOT/src/compiled.h])
+  AC_MSG_CHECKING([for GAP >= 4.9])
+  # test if this GAP >= 4.9
+  if test "x$GAP_CPPFLAGS" != x; then
+    AC_MSG_RESULT([yes])
   else
-    AC_MSG_RESULT([Not found])
-    bad=1
-  fi
-  AC_MSG_CHECKING([for GAP config.h])
-  if test -r $GAPROOT/bin/$GAPARCH/config.h; then
-    AC_MSG_RESULT([$GAPROOT/bin/$GAPARCH/config.h])
-  else
-    AC_MSG_RESULT([Not found])
-    bad=1
-  fi
+    AC_MSG_RESULT([no])
+    #####################################
+    # Now check for the GAP header files
 
-  if test "x$bad" = "x1"; then
-    echo ""
-    echo "********************************************************************"
-    echo "  ERROR"
-    echo ""
-    echo "  Failed to find the GAP source header files in src/ and"
-    echo "  GAP's config.h in the architecture dependend directory"
-    echo ""
-    echo "  The kernel build process expects to find the normal GAP "
-    echo "  root directory structure as it is after building GAP itself, and"
-    echo "  in particular the files"
-    echo "      <gaproot>/sysinfo.gap"
-    echo "      <gaproot>/src/<includes>"
-    echo "  and <gaproot>/bin/<architecture>/bin/config.h."
-    echo "  Please make sure that your GAP root directory structure"
-    echo "  conforms to this layout, or give the correct GAP root using"
-    echo "  --with-gaproot=<path>"
-    echo "********************************************************************"
-    echo ""
-    AC_MSG_ERROR([Unable to find GAP include files in /src subdirectory])
+    bad=0
+    AC_MSG_CHECKING([for GAP include files])
+    if test -r $GAPROOT/src/compiled.h; then
+      AC_MSG_RESULT([$GAPROOT/src/compiled.h])
+    else
+      AC_MSG_RESULT([Not found])
+      bad=1
+    fi
+    AC_MSG_CHECKING([for GAP config.h])
+    if test -r $GAPROOT/bin/$GAPARCH/config.h; then
+      AC_MSG_RESULT([$GAPROOT/bin/$GAPARCH/config.h])
+    else
+      AC_MSG_RESULT([Not found])
+      bad=1
+    fi
+
+    if test "x$bad" = "x1"; then
+      echo ""
+      echo "********************************************************************"
+      echo "  ERROR"
+      echo ""
+      echo "  Failed to find the GAP source header files in src/ and"
+      echo "  GAP's config.h in the architecture dependend directory"
+      echo ""
+      echo "  The kernel build process expects to find the normal GAP "
+      echo "  root directory structure as it is after building GAP itself, and"
+      echo "  in particular the files"
+      echo "      <gaproot>/sysinfo.gap"
+      echo "      <gaproot>/src/<includes>"
+      echo "  and <gaproot>/bin/<architecture>/bin/config.h."
+      echo "  Please make sure that your GAP root directory structure"
+      echo "  conforms to this layout, or give the correct GAP root using"
+      echo "  --with-gaproot=<path>"
+      echo "********************************************************************"
+      echo ""
+      AC_MSG_ERROR([Unable to find GAP include files in /src subdirectory])
+    fi
+
+    ARCHPATH=$GAPROOT/bin/$GAPARCH
+    GAP_CPPFLAGS="-I$GAPROOT -iquote $GAPROOT/src -I$ARCHPATH"
+
+    AC_MSG_CHECKING([for GAP's gmp.h location])
+    if test -r "$ARCHPATH/extern/gmp/include/gmp.h"; then
+      GAP_CPPFLAGS="$GAP_CPPFLAGS -I$ARCHPATH/extern/gmp/include"
+      AC_MSG_RESULT([$ARCHPATH/extern/gmp/include/gmp.h])
+    else
+      AC_MSG_RESULT([not found, GAP was compiled without its own GMP])
+    fi
   fi
-
-  ARCHPATH=$GAPROOT/bin/$GAPARCH
-  GAP_CPPFLAGS="-I$GAPROOT -I$ARCHPATH"
-
-  AC_MSG_CHECKING([for GAP's gmp.h location])
-  if test -r "$ARCHPATH/extern/gmp/include/gmp.h"; then
-    GAP_CPPFLAGS="$GAP_CPPFLAGS -I$ARCHPATH/extern/gmp/include"
-    AC_MSG_RESULT([$ARCHPATH/extern/gmp/include/gmp.h])
-  else
-    AC_MSG_RESULT([not found, GAP was compiled without GMP])
-  fi;
 
   AC_SUBST(GAPARCH)
   AC_SUBST(GAPROOT)
   AC_SUBST(GAP_CPPFLAGS)
+  AC_SUBST(GAP_LDLAGS)
+  AC_SUBST(GAP_LIBS)
 
   AC_LANG_POP([C])
 ])


### PR DESCRIPTION
This is the version of these autoconf macros currently used
by the IO package. The changes in here make the build system
use compiler flags provided by GAP, which should make it easier
to adapt to future changes on the GAP side.

This is needed for https://github.com/gap-system/gap/pull/2412