### PR TITLE
Avoid using C_NEW_STRING_DYN

### DIFF
--- a/src/gap_cpp_headers/gap_cpp_mapping.hpp
+++ b/src/gap_cpp_headers/gap_cpp_mapping.hpp
@@ -379,8 +379,9 @@ struct GAP_maker<std::string>
     Obj operator()(const std::string& s) const
     {
       Obj o;
-      const char* c = s.c_str();
-      C_NEW_STRING_DYN(o, c);
+      size_t len = s.length();
+      o = NEW_STRING(len);
+      memcpy(CHARS_STRING(o), s.c_str(), len);
       return o;
     }
 };


### PR DESCRIPTION
This is the last remaining use of C_NEW_STRING_DYN; after a release
of profiling with it removed has been made, we can remove it from GAP.