### PR TITLE
ProfileLine and ProfilePackage

### DIFF
--- a/gap/profiling.gd
+++ b/gap/profiling.gd
@@ -114,3 +114,37 @@ DeclareGlobalFunction("OutputCoverallsJsonCoverage");
 #!   browser.
 #!   <P/>
 DeclareGlobalFunction("LineByLineProfileFunction");
+
+#! @Arguments file[, opts]
+#! @Returns
+#!   a string
+#! @Description
+#!   Tests the file with name <A>file</A> in another GAP session, and produces a
+#!   code coverage report of lines that were executed in the process.  If
+#!   <A>file</A> ends with <C>.tst</C> it will be called with <C>Test</C>;
+#!   otherwise, it will be run directly.
+#!
+#!   The optional argument <A>opts</A> should be a record, and may contain any
+#!   of the following components:
+#!     * <C>outdir</C>: a string denoting the directory into which the HTML
+#!       files of the report will be placed (a temporary directory by default);
+#!     * <C>indir</C>: a string such that only file paths beginning with
+#!       <C>indir</C> will be profiled (default <C>""</C>);
+#!     * <C>showOutput</C>: a boolean denoting whether to print test output to
+#!       the screen (default <C>true</C>);
+#!     * <C>open</C>: a boolean denoting whether to open the report in a web
+#!       browser on completion (default <C>false</C>).
+#!
+#!   This function returns the location of an HTML file containing the report.
+DeclareGlobalFunction("ProfileFile");
+
+#! @Arguments pkg_name[, opts]
+#! @Returns
+#!   a string
+#! @Description
+#!   If <A>pkg_name</A> is the name of an installed package, then this function
+#!   runs that package's test suite and produces a report on the code coverage
+#!   of files inside the package.  The string returned denotes the location of
+#!   an HTML file containing the report.  The optional argument <A>opts</A>
+#!   behaves the same as in <Ref Func = "ProfileFile"/>.
+DeclareGlobalFunction("ProfilePackage");

--- a/gap/profiling.gi
+++ b/gap/profiling.gi
@@ -826,3 +826,102 @@ InstallGlobalFunction("LineByLineProfileFunction",
     fi;
   end);
 
+InstallGlobalFunction("ProfileFile",
+function(testfile, args...)
+  local opts, indir, showOutput, open, rnam, rawfile, redirect, len, gap_cmd,
+        cmd, x, page;
+  # Get options
+  opts := rec(outdir := DirectoryTemporary(),
+              indir := "",
+              showOutput := true,
+              open := false);
+  if Length(args) = 1 then
+    if not IsRecord(args[1]) then
+      ErrorNoReturn("ProfileFile: <opts> must be a record");
+    fi;
+    for rnam in RecNames(args[1]) do
+      opts.(rnam) := args[1].(rnam);
+    od;
+  elif Length(args) > 1 then
+    ErrorNoReturn("ProfileFile: takes 1 or 2 arguments, but ",
+                  Length(args) + 1, " were given");
+  fi;
+
+  # Gather data
+  rawfile := Filename(opts.outdir, "raw.json");
+  if opts.showOutput = true then
+    redirect := "";
+  else
+    redirect := "> /dev/null 2>&1";
+  fi;
+  len := Length(testfile);
+  gap_cmd := GAPInfo.KernelInfo.COMMAND_LINE[1];
+  if testfile{[len-3 .. len]} = ".tst" then
+    cmd := StringFormatted("""
+gapinput="Test(\"{}\"); quit;"
+{} --quitonbreak -a 500M -m 500M -A -q --cover {} {} <<EOF
+$gapinput
+EOF
+    """, testfile, gap_cmd, rawfile, redirect);
+  else
+    cmd := StringFormatted("""
+{} --quitonbreak -a 500M -m 500M -A -q --cover {} {} {} <<EOF
+quit; quit;
+EOF
+    """, gap_cmd, rawfile, testfile, redirect);
+  fi;
+  Exec(cmd);
+
+  # Process profile
+  x := ReadLineByLineProfile(rawfile);;
+  OutputAnnotatedCodeCoverageFiles(x, opts.indir, opts.outdir);
+  page := Filename(opts.outdir, "index.html");
+
+  # Open page
+  if opts.open = true then
+    if ARCH_IS_MAC_OS_X() then
+      Exec(Concatenation("open ", page));
+    elif ARCH_IS_WINDOWS() then
+      Exec(Concatenation("cmd /c start ", page));
+    else
+      Exec(Concatenation("xdg-open ", page));
+    fi;
+  fi;
+
+  return page;
+end);
+
+InstallGlobalFunction("ProfilePackage",
+function(pkg_name, args...)
+  local info, dir, testfile, opts, rnam;
+  # Check input
+  if Length(args) = 0 then
+    args := [rec()];
+  elif Length(args) > 1 then
+    ErrorNoReturn("ProfilePackage: takes 1 or 2 arguments, but ",
+                  Length(args) + 1, " were given");
+  fi;
+
+  # Get test location from package info
+  info := PackageInfo(pkg_name);
+  if Length(info) = 0 then
+    return fail;
+  fi;
+  if not IsBound(info[1].TestFile) then
+    ErrorNoReturn("ProfilePackage: no test file specified in package");
+  fi;
+  dir := info[1].InstallationPath;
+  testfile := Filename(Directory(dir), info[1].TestFile);
+  if Length(info) >= 2 then
+    Info(InfoWarning, 1, "ProfilePackage: \"", pkg_name,
+         "\" installed in two locations");
+    Info(InfoWarning, 1, "ProfilePackage: using ", dir, " . . .");
+  fi;
+
+  # Call ProfileFile with the correct options
+  opts := rec(indir := dir);
+  for rnam in RecNames(args[1]) do
+    opts.(rnam) := args[1].(rnam);
+  od;
+  return ProfileFile(testfile, opts);
+end);

--- a/tst/tstall/profilefile.tst
+++ b/tst/tstall/profilefile.tst
@@ -1,0 +1,22 @@
+# ProfileFile
+gap> tmpdir := DirectoryTemporary();;
+gap> quicktest := Filename(tmpdir, "quicktest.tst");;
+gap> runquicktest := Filename(tmpdir, "runquicktest.g");;
+gap> FileString(quicktest, "gap> Length([1,2,3]);\n3\n");;
+gap> FileString(runquicktest, StringFormatted("Test(\"{}\");\n", quicktest));;
+gap> Test(quicktest);
+true
+gap> Read(runquicktest);
+gap> str := ProfileFile(quicktest, rec(showOutput := false));;
+gap> EndsWith(str, ".html");
+true
+gap> str := ProfileFile(runquicktest);;
+gap> EndsWith(str, ".html");
+true
+
+# ProfilePackage
+gap> str := ProfilePackage("transgrp", rec(indir := "", showOutput := false));;
+gap> EndsWith(str, ".html");
+true
+gap> ProfilePackage("io", 2, 3);
+Error, ProfilePackage: takes 1 or 2 arguments, but 3 were given


### PR DESCRIPTION
Two months ago I made a [pull request to GAP](https://github.com/gap-system/gap/pull/2774) offering a simple shell script for profiling a package.  It was decided that GAP wasn't the place for it, and though I understand a couple of people have been passing it around, it doesn't currently have a home.

As an alternative, I decided (on @ChrisJefferson's advice) to write a new function to profile a package from inside GAP.  Hence this PR adds `ProfileFile` and `ProfilePackage`.  If you call something like `ProfilePackage("orb")`, the standard test suite in the orb package is run, and a line coverage report is produced.  The location of the HTML file is returned.

The two functions also take a record with a few possible options, including `open`, which opens a browser window at the end.

Documentation and tests are included.