### PR TITLE
Simplify use of GAP headers, avoid using gmp.h

### DIFF
--- a/src/gap_cpp_headers/gap_cpp_mapping.hpp
+++ b/src/gap_cpp_headers/gap_cpp_mapping.hpp
@@ -10,9 +10,8 @@
 #include <utility>
 #include <set>
 
-// We have to include this to get around problems with the 'extern C' wrapping of src/compiled.h,
-// which includes gmp, which in C++ mode has some C++ templates.
-#include "include_gap_headers.hpp"
+#include "src/compiled.h"   // GAP headers
+
 #include "gap_prototypes.hpp"
 #include "gap_exception.hpp"
 #include "gap_function.hpp"

--- a/src/gap_cpp_headers/gap_prototypes.hpp
+++ b/src/gap_cpp_headers/gap_prototypes.hpp
@@ -1,7 +1,7 @@
 #ifndef PROTOTYPES_HPP_ZLALA
 #define PROTOTYPES_HPP_ZLALA
 
-#include "include_gap_headers.hpp"
+#include "src/compiled.h"   // GAP headers
 
 namespace GAPdetail
 {

--- a/src/gap_cpp_headers/gap_wrapping.hpp
+++ b/src/gap_cpp_headers/gap_wrapping.hpp
@@ -1,7 +1,8 @@
 #ifndef _GAP_WRAP_HPP_AQD
 #define _GAP_WRAP_HPP_AQD
 
-#include "include_gap_headers.hpp"
+#include "src/compiled.h"   // GAP headers
+
 #include "gap_prototypes.hpp"
 #include "gap_exception.hpp"
 

--- a/src/gap_cpp_headers/include_gap_headers.hpp
+++ b/src/gap_cpp_headers/include_gap_headers.hpp
@@ -1,9 +1,0 @@
-#ifndef _GAP_HEADERS_H_QEHJ
-#define _GAP_HEADERS_H_QEHJ
-
-#include <gmp.h>
-extern "C" {
-#include "src/compiled.h"
-}
-
-#endif


### PR DESCRIPTION
The GAP headers have for quite some time now (at the very least since GAP 4.9)
worked cleanly when used from C++ code, without any need to do a manual
`extern "C"` or perform tricks to get gmp.h working right. With GAP 4.11, it
will be even better, because gmp.h won't be included by any GAP headers
anymore.

Fixes #26