### PR TITLE
Update Travis settings; test against GAP 4.11; require GAP 4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,21 @@ addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
-    - libgmp-dev:i386
-    - libreadline-dev:i386
-    - gcc-multilib
-    - g++-multilib
+    - zlib1g-dev
 
 matrix:
   include:
-    - env: GAPBRANCH=master ABI=32
     - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.11
     - env: GAPBRANCH=stable-4.10
+    - env: GAPBRANCH=master ABI=32
+      addons:
+        apt_packages:
+          - libgmp-dev:i386
+          - libreadline-dev:i386
+          - zlib1g-dev:i386
+          - gcc-multilib
+          - g++-multilib
 
 branches:
   except:
@@ -31,5 +36,5 @@ before_script:
 script:
   - scripts/build_pkg.sh && scripts/run_tests.sh
 after_script:
-  - bash scripts/gather-coverage.sh
+  - scripts/gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -69,7 +69,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.9",
+  GAP := ">= 4.10",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ], ["IO", ">= 4.4.4" ] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],


### PR DESCRIPTION
Since PackageInfo.g claims compatibility with GAP 4.9, test against that, too. (Perhaps this is wrong, then of course `PackageInfo.g` should be adjusted instead. Well, we'll soon know for sure :-)