### PR TITLE
Use char instead of Char, fix GC bug

### DIFF
--- a/src/profiling.cc
+++ b/src/profiling.cc
@@ -541,11 +541,11 @@ Obj HTMLEncodeString(Obj self, Obj param)
   }
 
   Int len = GET_LEN_STRING(param);
-  Char* ptr = CSTR_STRING(param);
   // Make long enough there is no chance a
   // resize will be needed.
   Obj outstring = NEW_STRING(len * 6);
-  Char* outptr = CSTR_STRING(outstring);
+  const char* ptr = CONST_CSTR_STRING(param);
+  char* outptr = CSTR_STRING(outstring);
   Int outpos = 0;
   for(Int i = 0; i < len; ++i)
   {


### PR DESCRIPTION
The call to NEW_STRING could trigger a GC and thus invalidate ptr.
Fix this by reordering commands. Also use char instead of Char, so
that the GAP kernel can eventually get rid of the latter. Finally,
switch ptr to a const pointer, as we are only reading from it.