### PR TITLE
Fix clang compiler warning

### DIFF
--- a/src/md5.cc
+++ b/src/md5.cc
@@ -175,7 +175,7 @@ void MD5Final(uint8_t digest[16], struct MD5Context *ctx)
  */
 void MD5Transform(uint32_t buf[4], const uint8_t inraw[64])
 {
-	register uint32_t a, b, c, d;
+	uint32_t a, b, c, d;
 	uint32_t in[16];
 	int i;
 


### PR DESCRIPTION
warning: 'register' storage class specifier is deprecated and incompatible with C++17
