### PR TITLE
Drop 32bit CI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }} ${{ matrix.ABI }}
+    name: ${{ matrix.gap-branch }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -28,10 +28,6 @@ jobs:
           - stable-4.12
           - stable-4.11
           - stable-4.10
-        ABI: ['']
-        include:
-          - gap-branch: master
-            ABI: 32
 
     steps:
       - uses: actions/checkout@v3
@@ -39,7 +35,6 @@ jobs:
         with:
           GAP_PKGS_TO_BUILD: 'io' # exclude profiling, i.e., *this* package
           GAPBRANCH: ${{ matrix.gap-branch }}
-          ABI: ${{ matrix.ABI }}
       - uses: gap-actions/build-pkg@v1
       - uses: gap-actions/run-pkg-tests@v2
         with:


### PR DESCRIPTION
The latest Ubuntu is missing several packages required for this
