### PR TITLE
Replace compiled.h by gap_all.h

### DIFF
--- a/src/gap_cpp_headers/gap_cpp_mapping.hpp
+++ b/src/gap_cpp_headers/gap_cpp_mapping.hpp
@@ -12,7 +12,7 @@
 #include <utility>
 #include <set>
 
-#include "compiled.h"   // GAP headers
+#include "gap_all.h"   // GAP headers
 
 #include "gap_prototypes.hpp"
 #include "gap_exception.hpp"

--- a/src/gap_cpp_headers/gap_prototypes.hpp
+++ b/src/gap_cpp_headers/gap_prototypes.hpp
@@ -3,7 +3,7 @@
 #ifndef PROTOTYPES_HPP_ZLALA
 #define PROTOTYPES_HPP_ZLALA
 
-#include "compiled.h"   // GAP headers
+#include "gap_all.h"   // GAP headers
 
 namespace GAPdetail
 {

--- a/src/gap_cpp_headers/gap_wrapping.hpp
+++ b/src/gap_cpp_headers/gap_wrapping.hpp
@@ -3,7 +3,7 @@
 #ifndef _GAP_WRAP_HPP_AQD
 #define _GAP_WRAP_HPP_AQD
 
-#include "compiled.h"   // GAP headers
+#include "gap_all.h"   // GAP headers
 
 #include "gap_prototypes.hpp"
 #include "gap_exception.hpp"


### PR DESCRIPTION
No functional change for this package but makes it future-proof.

Please consider making (yet another) release soon.