### PR TITLE
Modernise the Cygwin CI setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,8 @@
 name: CI
 
-# Trigger the workflow on push or pull request
+# Trigger the workflow on push or pull request or manually
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -18,85 +19,43 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
-    runs-on: ubuntu-latest
+    name: "GAP ${{ matrix.gap-branch }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu
         gap-branch:
           - master
+          - stable-4.15
           - stable-4.14
           - stable-4.13
           - stable-4.12
+        include:
+          - os: windows
+            gap-branch: master
 
     steps:
       - uses: actions/checkout@v5
+      - uses: gap-actions/setup-cygwin@v2
+        if: ${{ runner.os == 'Windows' }}
       - uses: gap-actions/setup-gap@v2
         with:
           GAP_PKGS_TO_BUILD: 'io' # exclude profiling, i.e., *this* package
           GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v3
+      - uses: gap-actions/build-pkg@v2
+      - uses: gap-actions/run-pkg-tests@v4
         with:
-          NO_COVERAGE: 'yes'
-      - uses: gap-actions/run-pkg-tests@v3
+          coverage: false
+      - uses: gap-actions/run-pkg-tests@v4
+        if: ${{ runner.os != 'Windows' }}
         with:
-          NO_COVERAGE: 'yes'
-          only-needed: true
+          coverage: false
+          mode: 'onlyneeded'
       - name: "Generate source coverage reports by running gcov"
+        shell: bash
         run: find . -type f -name '*.gcno' -exec gcov -pb {} +
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  # The Cygwin job
-  test-cygwin:
-    name: 'cygwin64 - GAP master'
-    runs-on: windows-2022
-    env:
-      CHERE_INVOKING: 1
-    steps:
-      - uses: actions/checkout@v5
-      - uses: gap-actions/setup-cygwin@v1
-      - uses: gap-actions/setup-gap@cygwin-v2
-        with:
-          GAP_PKGS_TO_BUILD: 'io'
-      - uses: gap-actions/build-pkg@cygwin-v1
-      # HACK: This test fails in GitHub Actions Cygwin
-      - name: "HACK: Remove failing test files"
-        run: rm tst/tstall/profilefile.tst
-        shell: bash
-      - uses: gap-actions/run-pkg-tests@cygwin-v2
-        with:
-          NO_COVERAGE: 'yes'
-      # Coverage seems to be broken in Cygwin
-      #- name: "Generate source coverage reports by running gcov"
-      #  run: find . -type f -name '*.gcno' -exec gcov -pb {} +
-      #  shell: bash
-      #- uses: codecov/codecov-action@v5
-      #  with:
-      #    token: ${{ secrets.CODECOV_TOKEN }}
-      - name: "Setup tmate session"
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ failure() }}
-        timeout-minutes: 15
-
-  # The documentation job
-  manual:
-    name: Build manuals
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v5
-      - uses: gap-actions/setup-gap@v2
-        with:
-          GAP_PKGS_TO_BUILD: "io" # exclude profiling, i.e., *this* package
-      - uses: gap-actions/build-pkg-docs@v1
-        with:
-          use-latex: 'true'
-      - name: 'Upload documentation'
-        uses: actions/upload-artifact@v4
-        with:
-          name: manual
-          path: ./doc/manual.pdf
-          if-no-files-found: error

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,38 @@
+name: Build manual
+
+# Trigger the workflow on push or pull request or manually
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+
+# the `concurrency` settings ensure that not too many CI jobs run in parallel
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  # The documentation job
+  manual:
+    name: Build manuals
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: gap-actions/setup-gap@v2
+        with:
+          GAP_PKGS_TO_BUILD: "io" # exclude profiling, i.e., *this* package
+      - uses: gap-actions/build-pkg-docs@v1
+        with:
+          use-latex: 'true'
+      - name: 'Upload documentation'
+        uses: actions/upload-artifact@v4
+        with:
+          name: manual
+          path: ./doc/manual.pdf
+          if-no-files-found: error


### PR DESCRIPTION
* Merge the jobs for Unix and Windows jobs thanks to the magic of `gap-actions/setup-cygwin@v2` etc
* Add option to run these workflows manually
* Reinstate a test on Windows that used to not work
* Reinstate uploading code coverage on Windows

While I was at it I put the manual job into a separate file, so running that independently.